### PR TITLE
Use PaymentStatus enum in payment notifications

### DIFF
--- a/app/Services/Payment/PaymentService.php
+++ b/app/Services/Payment/PaymentService.php
@@ -96,22 +96,24 @@ class PaymentService
             $fraud = $notificationData['fraud_status'] ?? null;
 
             $paymentStatus = match ($transactionStatus) {
-                'capture' => ($type === 'credit_card' && $fraud === 'challenge') ? 'challenge' : 'success',
-                'settlement' => 'settlement',
-                'pending' => 'pending',
-                'deny' => 'deny',
-                'expire' => 'expired',
-                'cancel' => 'cancel',
-                default => 'unknown',
+                PaymentStatus::Capture->value => ($type === 'credit_card' && $fraud === PaymentStatus::Challenge->value)
+                    ? PaymentStatus::Challenge
+                    : PaymentStatus::Success,
+                PaymentStatus::Settlement->value => PaymentStatus::Settlement,
+                PaymentStatus::Pending->value => PaymentStatus::Pending,
+                PaymentStatus::Deny->value => PaymentStatus::Deny,
+                'expire' => PaymentStatus::Expired,
+                PaymentStatus::Cancel->value => PaymentStatus::Cancel,
+                default => PaymentStatus::Unknown,
             };
 
             $paymentTransaction->update([
                 'payment_type' => $type,
-                'status' => $paymentStatus,
+                'status' => $paymentStatus->value,
                 'raw_response' => $rawBody,
             ]);
 
-            if (in_array($paymentStatus, [PaymentStatus::Settlement->value, PaymentStatus::Success->value, PaymentStatus::Capture->value])) {
+            if ($paymentStatus->isPaid()) {
                 $sale = $paymentTransaction->sale;
                 if ($sale && $sale->status !== SaleStatus::Completed->value) {
                     $sale->update(['status' => SaleStatus::Completed->value]);

--- a/tests/Unit/Services/PaymentServiceTest.php
+++ b/tests/Unit/Services/PaymentServiceTest.php
@@ -57,6 +57,66 @@ it('can handle notification and update sale status to completed', function () {
     expect($product->fresh()->stock)->toBe(8); // Stock reduced on settlement
 });
 
+
+it('uses payment status enum values for non-paid notification statuses', function (string $transactionStatus, string $expectedStatus) {
+    $transaction = PaymentTransaction::factory()->create([
+        'external_id' => 'ORDER-'.$transactionStatus,
+        'amount' => 10000,
+        'status' => 'pending',
+    ]);
+
+    $statusCode = '200';
+    $grossAmount = '10000.00';
+    $signatureKey = hash('sha512', $transaction->external_id.$statusCode.$grossAmount.'test_server_key');
+
+    $notificationData = [
+        'order_id' => $transaction->external_id,
+        'status_code' => $statusCode,
+        'gross_amount' => $grossAmount,
+        'signature_key' => $signatureKey,
+        'transaction_status' => $transactionStatus,
+        'payment_type' => 'qris',
+    ];
+
+    $response = $this->paymentService->handleNotification($notificationData, json_encode($notificationData));
+
+    expect($response['status'])->toBe(200);
+    expect($transaction->fresh()->status)->toBe($expectedStatus);
+})->with([
+    'pending' => ['pending', 'pending'],
+    'deny' => ['deny', 'deny'],
+    'expire' => ['expire', 'expired'],
+    'cancel' => ['cancel', 'cancel'],
+    'unknown' => ['unexpected-status', 'unknown'],
+]);
+
+it('uses challenge enum value for challenged credit card captures', function () {
+    $transaction = PaymentTransaction::factory()->create([
+        'external_id' => 'ORDER-CHALLENGE',
+        'amount' => 10000,
+        'status' => 'pending',
+    ]);
+
+    $statusCode = '200';
+    $grossAmount = '10000.00';
+    $signatureKey = hash('sha512', $transaction->external_id.$statusCode.$grossAmount.'test_server_key');
+
+    $notificationData = [
+        'order_id' => $transaction->external_id,
+        'status_code' => $statusCode,
+        'gross_amount' => $grossAmount,
+        'signature_key' => $signatureKey,
+        'transaction_status' => 'capture',
+        'payment_type' => 'credit_card',
+        'fraud_status' => 'challenge',
+    ];
+
+    $response = $this->paymentService->handleNotification($notificationData, json_encode($notificationData));
+
+    expect($response['status'])->toBe(200);
+    expect($transaction->fresh()->status)->toBe('challenge');
+});
+
 it('throws exception for invalid signature', function () {
     $notificationData = [
         'order_id' => 'ORDER-123',


### PR DESCRIPTION
Summary:
- Map Midtrans notification statuses to PaymentStatus enum cases instead of hardcoded result strings.
- Persist the enum value and use PaymentStatus::isPaid() for paid-state checks.
- Add regression coverage for pending, deny, expire, cancel, unknown, and challenged capture statuses.

Validation:
- git diff --check
- Could not run PHP/Laravel tests locally because php and composer are not installed in this environment.

Fixes #89